### PR TITLE
Add list of offices in main navigation.

### DIFF
--- a/elements/elements.html
+++ b/elements/elements.html
@@ -19,6 +19,7 @@
 <link rel="import" href="../bower_components/google-chart/google-chart.html">
 
 <link rel="import" href="bar-charts.html">
+<link rel="import" href="list-of-offices.html">
 <link rel="import" href="main-page.html">
 
 <link rel="import" href="google-analytics.html">

--- a/elements/list-of-offices.html
+++ b/elements/list-of-offices.html
@@ -1,0 +1,10 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+
+<polymer-element name="list-of-offices" attributes="source" noscript>
+  <template>
+    <core-ajax auto url="{{source}}" response="{{items}}" handleAs="json"></core-ajax>
+    <template repeat="{{item in items}}">
+      <core-item label="{{item.Office}}"></core-item>
+    </template>
+  </template>
+</polymer-element>

--- a/elements/main-page.html
+++ b/elements/main-page.html
@@ -15,6 +15,9 @@
                 <core-item icon="visibility" id="industryinfluence" label="influential industries"></core-item>
                 <core-item icon="visibility" id="officeholders" label="office holders"></core-item>
                 <core-item icon="info-outline" id="about" label="about"></core-item>
+                <core-submenu>
+                  <list-of-offices source="json/years and offices.json"></list-of-offices>
+                </core-submenu>
             </core-menu>
         </core-header-panel>
         <div tool>DC Campaign Finance Watch</div>


### PR DESCRIPTION
It would be nice if we didn’t have the series of data as the left navigation, but rather the list of offices. Then, per office, show each series as a graph.

This should let us compare across series a bit better.

There aren’t any pages wired up to these entries, as the data set isn’t ordered to support it.

I’m a bit fizzled out on the whole Polymer thing, but here’s what I’ve got in case you want it!
