### PR TITLE
DB upgrade script for candidate to campaign contributions

### DIFF
--- a/api/candidate/candidate.service.js
+++ b/api/candidate/candidate.service.js
@@ -102,7 +102,7 @@ exports.findCandidate = function (candidateId, campaignIds, toDate, fromDate) {
                         });
 
                         var candidateContributionAmount = newContribs.reduce(function(total, c){
-                            if(c.contributor.contributorType === 'Candidate') {
+                            if(c.selfContribution) {
                                 return total + c.amount;
                             }
                             return total;

--- a/importer/fixCandidateContributionType.js
+++ b/importer/fixCandidateContributionType.js
@@ -1,0 +1,59 @@
+var Promise = require('bluebird');
+var _ = require('lodash');
+var async = require('async');
+var Contributions = require('../models/contribution');
+var Contributors = require('../models/contributor');
+var Candidates = require('../models/candidate');
+
+//Mongoose
+var mongoose = require('mongoose');
+mongoose.Promise = Promise;
+mongoose.connect('mongodb://localhost:27017/dc-campaign-finance', {
+    server: {
+        socketOptions: {
+            keepAlive: 5,
+            connectTimeoutMS: 30000
+        }
+    }
+});
+
+var fixed = 0;
+Candidates.find()
+    .then(function(candidates){
+        return Promise.map(candidates, function(c){
+            // Check to see if the candidate has all contributed to a campaign
+            return Contributors.find({name: c.name.trim()})
+                .then(function(contributors){
+                    if(contributors.length === 1) {
+                        // If the candiate has contributed find all contributions
+                        // to her/his own campaign and update that contribution
+                        return Contributions.find({contributor: contributors[0].id, candidate: c.id})
+                            .then(function(contributions){
+                                var updatePromises = contributions.map(function(contrib){
+                                    return Contributions.findByIdAndUpdate(contrib.id, {
+                                        $set: {
+                                            selfContribution: true
+                                        }
+                                    });
+                                });
+                                return Promise.all(updatePromises);
+                            })
+                            .then(function(){
+                                // Finally update that contributor record to type individual
+                                var contributorToFix = contributors[0];
+                                return Contributors.findByIdAndUpdate(contributorToFix.id, {
+                                    $set: {
+                                        contributorType: 'Individual'
+                                    }
+                                });
+                            });
+                    }
+                    return [];
+                });
+        },{concurrency: 5});
+    })
+    .then(function(){
+        console.log('done', fixed);
+        mongoose.disconnect();
+        process.exit();
+    });

--- a/models/contribution.js
+++ b/models/contribution.js
@@ -24,7 +24,8 @@ var contributionSchema = new Schema({
     amount: Number,
     contributionType: String,
     rawContribution: String,
-    rawId: String
+    rawId: String,
+    selfContribution: Boolean
 });
 
 contributionSchema.index({candidate: 1, date: 1});


### PR DESCRIPTION
## Description
This change will fix the issue where candidate contributions have been mislabeled.  All contributions will now have a selfContributions to field to keep track of this fact

## Motivation and Context
Candidate to campaign contributions will now be correct.  If a candidate contributes, they will be marked as an individual contributor.  If the contribution is to their own campaign that contribution will be marked as a selfContribution.
Fixes #140 

## How Has This Been Tested?
Verified with Charles Allen 2014 Ward Race.  Total contribution was $155079, percent from candidate is 0.004681484920588861 which is equal to his total contributions as calculated from the raw spreadsheet of $726.


## Screenshots (highly recommended):
<img width="893" alt="screen shot 2016-04-11 at 8 44 37 pm" src="https://cloud.githubusercontent.com/assets/1225895/14446639/4310761e-0026-11e6-9ae5-d402ceb9e6ec.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I've talked through the changes with a team lead
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Model change to that contribution field includes self contribution field
Service change to use self contribution field to calculate donations by a candidate