### PR TITLE
Adding markdownify to support importing markdown files

### DIFF
--- a/client/js/candidateCard.component.jsx
+++ b/client/js/candidateCard.component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ChartSelectorComponent from './chartSelector.jsx';
 import ChartContainerComponent from './chartContainerComponent.jsx';
 import _ from 'lodash';
+import { Link } from 'react-router';
 import Client from './api';
 import Promise from 'bluebird';
 import {
@@ -35,7 +36,7 @@ const CandidateInfo = (props) => {
             <div className="col-sm-12">
                 <h4>Campaign Scores</h4>
                 <h4>Combined Score: {(_.round(info.scores.total,2))} (out of 100 points)</h4>
-                <h5>Scores range from 0-100. See here for explanation.</h5>
+                <h5>Scores range from 0-100. See <Link to="faq#scorecard">here</Link> for explanation.</h5>
 
                 <h5>Location (40 points)</h5>
                 <div>% of Money from DC Addresses: {(_.round(info.scores.dcContribScore,2))} (out of 25 points)</div>

--- a/client/js/faq/faqComponent.jsx
+++ b/client/js/faq/faqComponent.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {Grid, Row, Col} from 'react-bootstrap';
+import {Grid, Row, Col, Well} from 'react-bootstrap';
+
+var scorecard = require('../../../scorecard/README');
+
+function createScorecard() {
+    return { __html: scorecard};
+};
 
 const FaqComponent = () => (
     <Grid>
@@ -43,6 +49,14 @@ const FaqComponent = () => (
                 <div>
                     Please contact us with the data that might incorrect.  We're striving to keep the data as accurate as possible.
                 </div>
+            </Col>
+        </Row>
+        <Row>
+            <Col xs={12} id="scorecard">
+                <h4>What do the scores mean?</h4>
+                <Well>
+                    <div dangerouslySetInnerHTML={createScorecard()}></div>
+                </Well>
             </Col>
         </Row>
         <Row>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ var path = require('path');
 var fs = require('fs');
 var child_process = require('child_process');
 var shell = require('gulp-shell');
+var markdownify = require('markdownify');
 
 
 
@@ -23,7 +24,8 @@ var watchifyOpts = {
 };
 var bundler = browserify({
     entries: ['./client/index.jsx'],
-    debug: true
+    debug: true,
+    extensions: ['.md', 'markdown']
 });
 
 bundler.plugin(watchify, {
@@ -31,7 +33,8 @@ bundler.plugin(watchify, {
         ignoreWatch: ['**/node_modules/**'],
         poll: true
     })
-    .transform(babelify);
+    .transform(babelify)
+    .transform(markdownify);
 
 bundler.on('update', function () {
     gutil.log('file changed, browserify it');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gm": "^1.21.1",
     "jquery": "^2.2.1",
     "lodash": "^4.6.1",
+    "markdownify": "^0.1.0",
     "moment": "^2.10.6",
     "moment-range": "^2.0.3",
     "mongodb": "^2.1.8",


### PR DESCRIPTION
Provides proper linking to the readme version of the scorecard

## Motivation and Context
There has been a dead link for several months now

## How Has This Been Tested?
Tested on my local machine

## Screenshots (highly recommended):
![screen shot 2016-05-03 at 7 10 21 am](https://cloud.githubusercontent.com/assets/1225895/14981618/54948a4a-10fe-11e6-8dc4-99b0ad294f0a.png)
![screen shot 2016-05-03 at 7 10 30 am](https://cloud.githubusercontent.com/assets/1225895/14981619/58462ca2-10fe-11e6-8c6e-aa735dd85164.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ x ] I've talked through the changes with a team lead
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.

Added scorecard readme into faqs
Added link to faq#scorecard on the candidate page