### PR TITLE
resolve promise error on date range api search by formatting date before fetching

### DIFF
--- a/src/components/api.js
+++ b/src/components/api.js
@@ -58,9 +58,9 @@ class Client {
         '?raceType=' +
         race +
         '&fromDate=' +
-        dateRange.fromDate +
+        dateRange.fromDate.format(dateFormat) +
         '&toDate=' +
-        dateRange.toDate
+        dateRange.toDate.format(dateFormat)
     ).then(rsp => {
       return rsp.json();
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On date range change, there was a promise error. 
The promise error was a side effect of the date range iso format.
This formats the date before making the api request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Locally by switching date after selecting a race type.
e.g. Select Council then click Last Year, Last 2 Years, Last 10 Years
With each data clicked, the search results should vary.

## Screenshots (highly recommended):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I've talked through the changes with a team lead
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
